### PR TITLE
Feature/byte av losenord

### DIFF
--- a/src/main/js/App.js
+++ b/src/main/js/App.js
@@ -25,6 +25,7 @@ import {
 import CheckApproval from "./approval/CheckApproval";
 import Notifications from "./common/Notifications";
 import { NotificationProvider } from "./hooks/NotificationContext";
+import ChangePassword from "./changepassword/ChangePassword";
 
 const WithoutSession = (props) => {
     const session = useSession();
@@ -70,6 +71,7 @@ const App = () => {
                     <Route path="/register" element={<WithoutSession element={ <Register /> }/>}/>
                     <Route path="/approval" element={<RequiresSession element={ <CheckApproval /> }/>}/>
                     <Route path="/owner" element={<RequiresSession element={ <Owner /> }/>}/>
+                    <Route path="/changepassword" element={<RequiresSession element={ <ChangePassword /> }/>}/>
                     <Route path="/bunnies" element={<RequiresSession element={ <Bunnies /> }/>}/>
                     <Route path="/bunny" element={<RequiresSession element={ <Bunny /> }/>}/>
                     <Route path="/activation/:ownerId" element={<Activation />} />

--- a/src/main/js/Logout.js
+++ b/src/main/js/Logout.js
@@ -4,11 +4,11 @@ import { useNavigate } from "react-router-dom";
 import {useSession, useSessionUpdater} from "./hooks/SessionContext";
 import { useNotificationUpdater } from "./hooks/NotificationContext";
 
-const Logout = (props) => {
+const Logout = (_) => {
     const navigate = useNavigate();
     const session = useSession();
     const sessionUpdater = useSessionUpdater();
-    const [_, { notifyError } ] = useNotificationUpdater();
+    const [__, { notifyError, clearNotifications } ] = useNotificationUpdater();
 
     const onSuccessfulLogout = () => {
         sessionUpdater(undefined);
@@ -17,13 +17,14 @@ const Logout = (props) => {
 
     const logoutHandler = (e) => {
         e.preventDefault();
+        clearNotifications();
         logoutUser(onSuccessfulLogout, notifyError);
     }
 
     return (
         <div>
             {session ?
-                <button className="btn btn-primary float-end" onClick={logoutHandler}>Logga ut</button> :
+                <button className="btn btn-secondary float-end" onClick={logoutHandler}>Logga ut</button> :
                 null
             }
         </div>

--- a/src/main/js/changepassword/ChangePassword.js
+++ b/src/main/js/changepassword/ChangePassword.js
@@ -76,7 +76,7 @@ const ChangePassword = (_) => {
                                    value={values.currentPassword}
                                    className={errors.currentPassword ? "form-control is-invalid" : "form-control"}
                                    onChange={handleChange}
-                                   autocomplete="current-password"
+                                   autoComplete="current-password"
                             />
                             {errors.currentPassword && <div className="invalid-feedback">{errors.currentPassword}</div>}
                         </div>
@@ -90,7 +90,7 @@ const ChangePassword = (_) => {
                                    value={values.newPassword}
                                    className={errors.newPassword ? "form-control is-invalid" : "form-control"}
                                    onChange={handleChange}
-                                   autocomplete="new-password"
+                                   autoComplete="new-password"
                             />
                             {errors.newPassword && <div className="invalid-feedback">{errors.newPassword}</div>}
                         </div>
@@ -104,7 +104,7 @@ const ChangePassword = (_) => {
                                    value={values.newPassword2}
                                    className={errors.newPassword2 ? "form-control is-invalid" : "form-control"}
                                    onChange={handleChange}
-                                   autocomplete="new-password"
+                                   autoComplete="new-password"
                             />
                             {errors.newPassword2 && <div className="invalid-feedback">{errors.newPassword2}</div>}
                         </div>

--- a/src/main/js/changepassword/ChangePassword.js
+++ b/src/main/js/changepassword/ChangePassword.js
@@ -1,34 +1,125 @@
 import React from 'react';
-import OwnerForm from './OwnerForm';
-import { updateOwner } from '../utils/api';
+import { changeUserPassword } from '../utils/api';
 import { useNavigate } from "react-router-dom";
-import { useSession, useSessionUpdater } from "../hooks/SessionContext";
+import { useSession } from "../hooks/SessionContext";
 import { useNotificationUpdater } from "../hooks/NotificationContext";
+import useFormValidation from "../hooks/FormValidation";
 
-const Owner = (_) => {
-    const navigate = useNavigate();
-    const session = useSession();
-    const sessionUpdater = useSessionUpdater();
-    const [__, { notifyError, clearNotifications } ] = useNotificationUpdater();
+const INITIAL_STATE = {
+    currentPassword: "",
+    newPassword: "",
+    newPassword2: ""
+};
 
-    const onSuccessfulUpdate = async (user) => {
-		sessionUpdater({user});
-		navigate("/bunnies");
-	}
+const validate = (values) => {
+    const errors = {};
 
-    const submitForm = async (owner) => {
-        clearNotifications();
-        await updateOwner(session.user.id, owner, onSuccessfulUpdate, notifyError);
+    if (!values.currentPassword) {
+        errors.currentPassword = "Du måste ange ditt gamla lösenord!";
+    }
+    if (!values.newPassword) {
+        errors.newPassword = "Du måste ange ett lösenord!";
+    }
+    if (!values.newPassword2) {
+        errors.newPassword2 = "Du måste ange ett lösenord!";
+    }
+    if (values.newPassword !== values.newPassword2 ) {
+        errors.newPassword2 = "Du måste upprepa ditt lösenord!";
     }
 
-    const cancelForm = async () => {
-        clearNotifications();
+    return errors;
+}
+
+const ChangePassword = (_) => {
+    const navigate = useNavigate();
+    const session = useSession();
+    const [__, { notifyError, notifySuccess, clearNotifications } ] = useNotificationUpdater();
+
+    const onSuccessfulUpdate = async () => {
+        notifySuccess("Lösenord uppdaterat!")
         navigate("/bunnies");
     }
 
+    const submitHandler = async () => {
+        clearNotifications();
+        await changeUserPassword(session.user.id, values.currentPassword, values.newPassword, onSuccessfulUpdate, notifyError);
+    }
+
+    const cancelHandler = async () => {
+        clearNotifications();
+        navigate("/owner");
+    }
+
+    const {
+        handleSubmit,
+        handleChange,
+        handleBlur,
+        values,
+        errors,
+        isSubmitting
+    } = useFormValidation(INITIAL_STATE, validate, submitHandler);
+
     return (
-        <OwnerForm submitForm={submitForm} cancelForm={cancelForm}/>
+        <div className="row py-2">
+            <form onSubmit={handleSubmit} >
+                <div className="col-md-12">
+                    <h2 >Ändra ditt lösenord</h2>
+                </div>
+                <div className="col-md-12">
+                    <div className="row mb-2">
+                        <label htmlFor="currentpassword" className="col-md-6 col-form-label">Ditt gamla lösenord</label>
+                        <div className="col-md-6">
+                            <input autoFocus
+                                   id="currentPassword"
+                                   name="currentPassword"
+                                   type="password"
+                                   value={values.currentPassword}
+                                   className={errors.currentPassword ? "form-control is-invalid" : "form-control"}
+                                   onChange={handleChange}
+                                   autocomplete="current-password"
+                            />
+                            {errors.currentPassword && <div className="invalid-feedback">{errors.currentPassword}</div>}
+                        </div>
+                    </div>
+                    <div className="row mb-2">
+                        <label htmlFor="newPassword" className="col-md-6 col-form-label">Nytt lösenord</label>
+                        <div className="col-md-6">
+                            <input id="newPassword"
+                                   name="newPassword"
+                                   type="password"
+                                   value={values.newPassword}
+                                   className={errors.newPassword ? "form-control is-invalid" : "form-control"}
+                                   onChange={handleChange}
+                                   autocomplete="new-password"
+                            />
+                            {errors.newPassword && <div className="invalid-feedback">{errors.newPassword}</div>}
+                        </div>
+                    </div>
+                    <div className="row mb-2">
+                        <label htmlFor="newPassword2" className="col-md-6 col-form-label">Upprepa nytt lösenord</label>
+                        <div className="col-md-6">
+                            <input id="newPassword2"
+                                   name="newPassword2"
+                                   type="password"
+                                   value={values.newPassword2}
+                                   className={errors.newPassword2 ? "form-control is-invalid" : "form-control"}
+                                   onChange={handleChange}
+                                   autocomplete="new-password"
+                            />
+                            {errors.newPassword2 && <div className="invalid-feedback">{errors.newPassword2}</div>}
+                        </div>
+                    </div>
+                    <div className="row mb-2">
+                        <div className="col-sm-6 align-self-end" />
+                        <div className="col-sm-6">
+                            <button type="submit" className="btn btn-primary float-end" disabled={isSubmitting} >Ändra ditt lösenord</button>
+                            <button type="cancel" className="btn btn-secondary float-end me-2" disabled={isSubmitting} onClick={cancelHandler}>Avbryt</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
     );
 }
 
-export default Owner;
+export default ChangePassword;

--- a/src/main/js/changepassword/ChangePassword.js
+++ b/src/main/js/changepassword/ChangePassword.js
@@ -3,32 +3,7 @@ import { changeUserPassword } from '../utils/api';
 import { useNavigate } from "react-router-dom";
 import { useSession } from "../hooks/SessionContext";
 import { useNotificationUpdater } from "../hooks/NotificationContext";
-import useFormValidation from "../hooks/FormValidation";
-
-const INITIAL_STATE = {
-    currentPassword: "",
-    newPassword: "",
-    newPassword2: ""
-};
-
-const validate = (values) => {
-    const errors = {};
-
-    if (!values.currentPassword) {
-        errors.currentPassword = "Du måste ange ditt gamla lösenord!";
-    }
-    if (!values.newPassword) {
-        errors.newPassword = "Du måste ange ett lösenord!";
-    }
-    if (!values.newPassword2) {
-        errors.newPassword2 = "Du måste ange ett lösenord!";
-    }
-    if (values.newPassword !== values.newPassword2 ) {
-        errors.newPassword2 = "Du måste upprepa ditt lösenord!";
-    }
-
-    return errors;
-}
+import ChangePasswordForm from "./ChangePasswordForm";
 
 const ChangePassword = (_) => {
     const navigate = useNavigate();
@@ -40,7 +15,7 @@ const ChangePassword = (_) => {
         navigate("/bunnies");
     }
 
-    const submitHandler = () => {
+    const submitHandler = (values) => {
         clearNotifications();
         return changeUserPassword(session.user.id, values.currentPassword, values.newPassword, onSuccessfulUpdate, notifyError);
     }
@@ -50,77 +25,8 @@ const ChangePassword = (_) => {
         navigate("/owner");
     }
 
-    const {
-        handleSubmit,
-        handleChange,
-        handleBlur,
-        values,
-        errors,
-        isSubmitting
-    } = useFormValidation(INITIAL_STATE, validate, submitHandler);
-
     return (
-        <div className="row py-2">
-            <form onSubmit={handleSubmit} >
-                <div className="col-md-12">
-                    <h2 >Ändra ditt lösenord</h2>
-                </div>
-                <div className="col-md-12">
-                    <div className="row mb-2">
-                        <label htmlFor="currentpassword" className="col-md-6 col-form-label">Ditt gamla lösenord</label>
-                        <div className="col-md-6">
-                            <input autoFocus
-                                   id="currentPassword"
-                                   name="currentPassword"
-                                   type="password"
-                                   value={values.currentPassword}
-                                   className={errors.currentPassword ? "form-control is-invalid" : "form-control"}
-                                   onChange={handleChange}
-                                   autoComplete="current-password"
-                            />
-                            {errors.currentPassword && <div className="invalid-feedback">{errors.currentPassword}</div>}
-                        </div>
-                    </div>
-                    <div className="row mb-2">
-                        <label htmlFor="newPassword" className="col-md-6 col-form-label">Nytt lösenord</label>
-                        <div className="col-md-6">
-                            <input id="newPassword"
-                                   name="newPassword"
-                                   type="password"
-                                   value={values.newPassword}
-                                   className={errors.newPassword ? "form-control is-invalid" : "form-control"}
-                                   onChange={handleChange}
-                                   autoComplete="new-password"
-                            />
-                            {errors.newPassword && <div className="invalid-feedback">{errors.newPassword}</div>}
-                        </div>
-                    </div>
-                    <div className="row mb-2">
-                        <label htmlFor="newPassword2" className="col-md-6 col-form-label">Upprepa nytt lösenord</label>
-                        <div className="col-md-6">
-                            <input id="newPassword2"
-                                   name="newPassword2"
-                                   type="password"
-                                   value={values.newPassword2}
-                                   className={errors.newPassword2 ? "form-control is-invalid" : "form-control"}
-                                   onChange={handleChange}
-                                   autoComplete="new-password"
-                            />
-                            {errors.newPassword2 && <div className="invalid-feedback">{errors.newPassword2}</div>}
-                        </div>
-                    </div>
-                    <div className="row mb-2">
-                        <div className="col-sm-6 align-self-end" />
-                        <div className="col-sm-6">
-                            <button type="submit" className="btn btn-primary float-end" disabled={isSubmitting} >
-                                { isSubmitting && <span className="spinner-border spinner-border-sm mr-1"></span> }
-                                Ändra ditt lösenord</button>
-                            <button type="cancel" className="btn btn-secondary float-end me-2" disabled={isSubmitting} onClick={cancelHandler}>Avbryt</button>
-                        </div>
-                    </div>
-                </div>
-            </form>
-        </div>
+        <ChangePasswordForm submitHandler={submitHandler} cancelHandler={cancelHandler} />
     );
 }
 

--- a/src/main/js/changepassword/ChangePassword.js
+++ b/src/main/js/changepassword/ChangePassword.js
@@ -40,9 +40,9 @@ const ChangePassword = (_) => {
         navigate("/bunnies");
     }
 
-    const submitHandler = async () => {
+    const submitHandler = () => {
         clearNotifications();
-        await changeUserPassword(session.user.id, values.currentPassword, values.newPassword, onSuccessfulUpdate, notifyError);
+        return changeUserPassword(session.user.id, values.currentPassword, values.newPassword, onSuccessfulUpdate, notifyError);
     }
 
     const cancelHandler = async () => {
@@ -112,7 +112,9 @@ const ChangePassword = (_) => {
                     <div className="row mb-2">
                         <div className="col-sm-6 align-self-end" />
                         <div className="col-sm-6">
-                            <button type="submit" className="btn btn-primary float-end" disabled={isSubmitting} >Ändra ditt lösenord</button>
+                            <button type="submit" className="btn btn-primary float-end" disabled={isSubmitting} >
+                                { isSubmitting && <span className="spinner-border spinner-border-sm mr-1"></span> }
+                                Ändra ditt lösenord</button>
                             <button type="cancel" className="btn btn-secondary float-end me-2" disabled={isSubmitting} onClick={cancelHandler}>Avbryt</button>
                         </div>
                     </div>

--- a/src/main/js/changepassword/ChangePassword.js
+++ b/src/main/js/changepassword/ChangePassword.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import OwnerForm from './OwnerForm';
+import { updateOwner } from '../utils/api';
+import { useNavigate } from "react-router-dom";
+import { useSession, useSessionUpdater } from "../hooks/SessionContext";
+import { useNotificationUpdater } from "../hooks/NotificationContext";
+
+const Owner = (_) => {
+    const navigate = useNavigate();
+    const session = useSession();
+    const sessionUpdater = useSessionUpdater();
+    const [__, { notifyError, clearNotifications } ] = useNotificationUpdater();
+
+    const onSuccessfulUpdate = async (user) => {
+		sessionUpdater({user});
+		navigate("/bunnies");
+	}
+
+    const submitForm = async (owner) => {
+        clearNotifications();
+        await updateOwner(session.user.id, owner, onSuccessfulUpdate, notifyError);
+    }
+
+    const cancelForm = async () => {
+        clearNotifications();
+        navigate("/bunnies");
+    }
+
+    return (
+        <OwnerForm submitForm={submitForm} cancelForm={cancelForm}/>
+    );
+}
+
+export default Owner;

--- a/src/main/js/changepassword/ChangePasswordForm.js
+++ b/src/main/js/changepassword/ChangePasswordForm.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import useFormValidation from "../hooks/FormValidation";
+
+const INITIAL_STATE = {
+    currentPassword: "",
+    newPassword: "",
+    newPassword2: ""
+};
+
+const validate = (values) => {
+    const errors = {};
+
+    if (!values.currentPassword) {
+        errors.currentPassword = "Du måste ange ditt gamla lösenord!";
+    }
+    if (!values.newPassword) {
+        errors.newPassword = "Du måste ange ett lösenord!";
+    }
+    if (!values.newPassword2) {
+        errors.newPassword2 = "Du måste ange ett lösenord!";
+    }
+    if (values.newPassword !== values.newPassword2 ) {
+        errors.newPassword2 = "Du måste upprepa ditt lösenord!";
+    }
+
+    return errors;
+}
+
+const ChangePasswordForm = (props) => {
+
+    const {
+        handleSubmit,
+        handleChange,
+        handleBlur,
+        values,
+        errors,
+        isSubmitting
+    } = useFormValidation(INITIAL_STATE, validate, props.submitHandler);
+
+    return (
+        <div className="row py-2">
+            <form onSubmit={handleSubmit} >
+                <div className="col-md-12">
+                    <h2 >Ändra ditt lösenord</h2>
+                </div>
+                <div className="col-md-12">
+                    <div className="row mb-2">
+                        <label htmlFor="currentpassword" className="col-md-6 col-form-label">Ditt gamla lösenord</label>
+                        <div className="col-md-6">
+                            <input autoFocus
+                                   id="currentPassword"
+                                   name="currentPassword"
+                                   type="password"
+                                   value={values.currentPassword}
+                                   className={errors.currentPassword ? "form-control is-invalid" : "form-control"}
+                                   onChange={handleChange}
+                                   autoComplete="current-password"
+                            />
+                            {errors.currentPassword && <div className="invalid-feedback">{errors.currentPassword}</div>}
+                        </div>
+                    </div>
+                    <div className="row mb-2">
+                        <label htmlFor="newPassword" className="col-md-6 col-form-label">Nytt lösenord</label>
+                        <div className="col-md-6">
+                            <input id="newPassword"
+                                   name="newPassword"
+                                   type="password"
+                                   value={values.newPassword}
+                                   className={errors.newPassword ? "form-control is-invalid" : "form-control"}
+                                   onChange={handleChange}
+                                   autoComplete="new-password"
+                            />
+                            {errors.newPassword && <div className="invalid-feedback">{errors.newPassword}</div>}
+                        </div>
+                    </div>
+                    <div className="row mb-2">
+                        <label htmlFor="newPassword2" className="col-md-6 col-form-label">Upprepa nytt lösenord</label>
+                        <div className="col-md-6">
+                            <input id="newPassword2"
+                                   name="newPassword2"
+                                   type="password"
+                                   value={values.newPassword2}
+                                   className={errors.newPassword2 ? "form-control is-invalid" : "form-control"}
+                                   onChange={handleChange}
+                                   autoComplete="new-password"
+                            />
+                            {errors.newPassword2 && <div className="invalid-feedback">{errors.newPassword2}</div>}
+                        </div>
+                    </div>
+                    <div className="row mb-2">
+                        <div className="col-sm-6 align-self-end" />
+                        <div className="col-sm-6">
+                            <button type="submit" className="btn btn-primary float-end" disabled={isSubmitting} >
+                                { isSubmitting && <span className="spinner-border spinner-border-sm mr-1"></span> }
+                                Ändra ditt lösenord</button>
+                            <button type="cancel" className="btn btn-secondary float-end me-2" disabled={isSubmitting} onClick={props.cancelHandler}>Avbryt</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+export default ChangePasswordForm;

--- a/src/main/js/hooks/FormValidation.js
+++ b/src/main/js/hooks/FormValidation.js
@@ -9,7 +9,7 @@ function useFormValidation(initialState, validate, submitHandler) {
         if (isSubmitting) {
             const noErrors = Object.keys(errors).length === 0;
             if (noErrors) {
-                await submitHandler();
+                await submitHandler(values);
                 setSubmitting(false);
             } else {
                 setSubmitting(false);

--- a/src/main/js/hooks/FormValidation.js
+++ b/src/main/js/hooks/FormValidation.js
@@ -1,0 +1,49 @@
+import React, {useEffect, useState} from "react";
+
+function useFormValidation(initialState, validate, submitHandler) {
+    const [values, setValues] = useState(initialState);
+    const [errors, setErrors] = useState({});
+    const [isSubmitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (isSubmitting) {
+            const noErrors = Object.keys(errors).length === 0;
+            if (noErrors) {
+                submitHandler();
+                setSubmitting(false);
+            } else {
+                setSubmitting(false);
+            }
+        }
+    }, [errors]);
+
+    function handleChange(event) {
+        setValues({
+            ...values,
+            [event.target.name]: event.target.value
+        });
+    }
+
+    function handleBlur() {
+        const validationErrors = validate(values);
+        setErrors(validationErrors);
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+        const validationErrors = validate(values);
+        setErrors(validationErrors);
+        setSubmitting(true);
+    }
+
+    return {
+        handleSubmit,
+        handleChange,
+        handleBlur,
+        values,
+        errors,
+        isSubmitting
+    };
+}
+
+export default useFormValidation;

--- a/src/main/js/hooks/FormValidation.js
+++ b/src/main/js/hooks/FormValidation.js
@@ -5,17 +5,17 @@ function useFormValidation(initialState, validate, submitHandler) {
     const [errors, setErrors] = useState({});
     const [isSubmitting, setSubmitting] = useState(false);
 
-    useEffect(() => {
+    useEffect( async () => {
         if (isSubmitting) {
             const noErrors = Object.keys(errors).length === 0;
             if (noErrors) {
-                submitHandler();
+                await submitHandler();
                 setSubmitting(false);
             } else {
                 setSubmitting(false);
             }
         }
-    }, [errors]);
+    }, [errors, isSubmitting]);
 
     function handleChange(event) {
         setValues({

--- a/src/main/js/login/LoginForm.js
+++ b/src/main/js/login/LoginForm.js
@@ -32,6 +32,7 @@ const LoginForm = (props) => {
                                 type="text"
                                 className={isValidated && user === "" ? "form-control is-invalid" : "form-control"}
                                 id="username"
+                                autocomplete="username"
                                 onChange={e => setUser(e.target.value)}
                             />
                         </div>
@@ -43,6 +44,7 @@ const LoginForm = (props) => {
                                 type="password"
                                 className={isValidated && pwd === "" ? "form-control is-invalid" : "form-control"}
                                 id="password"
+                                autocomplete="current-password"
                                 onChange={e => setPwd(e.target.value)}
                             />
                         </div>

--- a/src/main/js/login/LoginForm.js
+++ b/src/main/js/login/LoginForm.js
@@ -32,7 +32,7 @@ const LoginForm = (props) => {
                                 type="text"
                                 className={isValidated && user === "" ? "form-control is-invalid" : "form-control"}
                                 id="username"
-                                autocomplete="username"
+                                autoComplete="username"
                                 onChange={e => setUser(e.target.value)}
                             />
                         </div>
@@ -44,7 +44,7 @@ const LoginForm = (props) => {
                                 type="password"
                                 className={isValidated && pwd === "" ? "form-control is-invalid" : "form-control"}
                                 id="password"
-                                autocomplete="current-password"
+                                autoComplete="current-password"
                                 onChange={e => setPwd(e.target.value)}
                             />
                         </div>

--- a/src/main/js/owner/OwnerForm.js
+++ b/src/main/js/owner/OwnerForm.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useSession } from "../hooks/SessionContext";
+import {Link} from "react-router-dom";
 
 const OwnerForm = (props) => {
 	
@@ -164,7 +165,9 @@ const OwnerForm = (props) => {
                     </div>
 					</fieldset>
                     <div className="row mt-2">
-                        <div className="col-sm-8"/>
+                        <div className="col-sm-8 align-self-end">
+                            <Link className="link-primary" to="/changepassword">Vill du byta ditt lösenord?</Link>
+                        </div>
                         <div className="col-sm-4">
                             <button type="submit" className="btn btn-primary float-end" disabled={!submit}>Spara</button>
                             <button type="cancel" className="btn btn-secondary float-end me-2" disabled={!submit} onClick={cancelHandler}>Avbryt</button>

--- a/src/main/js/register/RegisterForm.js
+++ b/src/main/js/register/RegisterForm.js
@@ -37,7 +37,7 @@ const RegisterForm = (props) => {
                                 type="text"
                                 className={isValidated && user === "" ? "form-control is-invalid" : "form-control"}
                                 id="userName"
-                                autocomplete="username"
+                                autoComplete="username"
                                 onChange={e => setUser(e.target.value)}
                             />
                             <div className="invalid-feedback">
@@ -52,7 +52,7 @@ const RegisterForm = (props) => {
                                 type="password"
                                 className={isValidated && pwd === "" ? "form-control is-invalid" : "form-control"}
                                 id="password"
-                                autocomplete="new-password"
+                                autoComplete="new-password"
                                 onChange={e => setPwd(e.target.value)}
                             />
                             <div className="invalid-feedback">
@@ -67,7 +67,7 @@ const RegisterForm = (props) => {
                                 type="password"
                                 className={isValidPwd ? "form-control" : "form-control is-invalid"}
                                 id="password2"
-                                autocomplete="new-password"
+                                autoComplete="new-password"
                                 onChange={e => setPwd2(e.target.value)}
                             />
                             <div className="invalid-feedback">

--- a/src/main/js/register/RegisterForm.js
+++ b/src/main/js/register/RegisterForm.js
@@ -37,6 +37,7 @@ const RegisterForm = (props) => {
                                 type="text"
                                 className={isValidated && user === "" ? "form-control is-invalid" : "form-control"}
                                 id="userName"
+                                autocomplete="username"
                                 onChange={e => setUser(e.target.value)}
                             />
                             <div className="invalid-feedback">
@@ -51,6 +52,7 @@ const RegisterForm = (props) => {
                                 type="password"
                                 className={isValidated && pwd === "" ? "form-control is-invalid" : "form-control"}
                                 id="password"
+                                autocomplete="new-password"
                                 onChange={e => setPwd(e.target.value)}
                             />
                             <div className="invalid-feedback">
@@ -65,6 +67,7 @@ const RegisterForm = (props) => {
                                 type="password"
                                 className={isValidPwd ? "form-control" : "form-control is-invalid"}
                                 id="password2"
+                                autocomplete="new-password"
                                 onChange={e => setPwd2(e.target.value)}
                             />
                             <div className="invalid-feedback">

--- a/src/main/js/utils/api.js
+++ b/src/main/js/utils/api.js
@@ -86,12 +86,12 @@ const activateOwner = async (id, user, pwd, successHandler, errorHandler) => {
     }
 }
 
-const changeUserPassword = async (id, oldPwd, newPwd, successHandler, errorHandler) => {
+const changeUserPassword = async (id, currentPassword, newPassword, successHandler, errorHandler) => {
 
-    const response = await fetch(`/api/owners/${id}/activate`, {
+    const response = await fetch(`/api/owners/${id}/password`, {
         method: 'PUT',
         headers: new Headers({'content-type': 'application/json'}),
-        body: JSON.stringify({currentPassword: oldPwd, newPassword: newPwd})
+        body: JSON.stringify({currentPassword, newPassword})
     });
 
     if (response.status === 204){
@@ -107,7 +107,7 @@ const changeUserPassword = async (id, oldPwd, newPwd, successHandler, errorHandl
         errorHandler("Okänd användare!")
     }
     else {
-        errorHandler("Något gick fel vid aktivering!")
+        errorHandler("Något gick fel vid updatering av lösenord!")
     }
 }
 

--- a/src/main/js/utils/api.js
+++ b/src/main/js/utils/api.js
@@ -101,7 +101,7 @@ const changeUserPassword = async (id, currentPassword, newPassword, successHandl
         errorHandler("Ogiltigt lösenord!")
     }
     else if (response.status === 401) {
-        errorHandler("Du måste vara inloggad!")
+        errorHandler("Det gamla lösenordet är felaktigt!")
     }
     else if (response.status === 404) {
         errorHandler("Okänd användare!")


### PR DESCRIPTION
En länk för att byta lösenord finns nu på Mitt konto-sidan. Lyckas man byta lösenord kommer man till /bunnies medans man vid cancel kommer tillbaka till Mitt konto.

Provade en minimal hook för validering, vilket är ungefär vad formic erbjuder. Jag tycker klient-side valideringen blir bättre när den är samlad i en funktion.

Om man anger ett felaktigt nuvarande lösenord som passerar klient-validering får man 401 från backend och som användare får man se "Du måste vara inloggad" vilket jag tror är förvirrande. Jag tänker att vi ändrar så att 401 säger "Felaktigt nuvarande lösenord" för användaren, vad säger ni?