### PR TITLE
Revert "Bump react-dom from 17.0.2 to 19.2.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "react": "^17.0.2",
         "react-bootstrap": "^2.0.2",
-        "react-dom": "^19.2.5",
+        "react-dom": "^17.0.2",
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
@@ -3313,15 +3313,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "license": "MIT",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-is": {
@@ -3503,10 +3504,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.2",
-    "react-dom": "^19.2.5",
+    "react-dom": "^17.0.2",
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit 31e510b2d83f24154219c9b5b0ce0b9bcbe23919.